### PR TITLE
add es params setting

### DIFF
--- a/elasticsearchreader/src/main/java/com/alibaba/datax/plugin/reader/elasticsearchreader/ESClient.java
+++ b/elasticsearchreader/src/main/java/com/alibaba/datax/plugin/reader/elasticsearchreader/ESClient.java
@@ -93,12 +93,19 @@ public class ESClient {
                                String index,
                                String type,
                                String scroll,
+                               Map<String, Object> params,
                                Map<String, Object> headers) throws IOException {
         Search.Builder searchBuilder = new Search.Builder(query)
                 .setSearchType(searchType)
                 .addIndex(index).addType(type).setHeader(headers);
         if (StringUtils.isNotBlank(scroll)) {
             searchBuilder.setParameter("scroll", scroll);
+        }
+        if(params != null && params.size() != 0) {
+            for (Map.Entry<String, Object> entry : params.entrySet()) {
+                log.info("elasticsearch set request params the item: " + entry.getKey() + ", and the value: " + entry.getValue());
+                searchBuilder.setParameter(entry.getKey(),entry.getValue());
+            }
         }
         return jestClient.execute(searchBuilder.build());
     }

--- a/elasticsearchreader/src/main/java/com/alibaba/datax/plugin/reader/elasticsearchreader/EsReader.java
+++ b/elasticsearchreader/src/main/java/com/alibaba/datax/plugin/reader/elasticsearchreader/EsReader.java
@@ -108,6 +108,7 @@ public class EsReader extends Reader {
         private String query;
         private String scroll;
         private EsTable table;
+        private Map<String, Object> params;
 
         @Override
         public void prepare() {
@@ -132,6 +133,7 @@ public class EsReader extends Reader {
             this.query = Key.getQuery(conf);
             this.scroll = Key.getScroll(conf);
             this.table = Key.getTable(conf);
+            this.params = Key.getParams(conf);
             if (table == null || table.getColumn() == null || table.getColumn().isEmpty()) {
                 throw DataXException.asDataXException(ESReaderErrorCode.COLUMN_CANT_BE_EMPTY, "请检查job的elasticsearchreader插件下parameter是否配置了table参数");
             }
@@ -145,7 +147,7 @@ public class EsReader extends Reader {
             queryPerfRecord.start();
             SearchResult searchResult;
             try {
-                searchResult = esClient.search(query, searchType, index, type, scroll, headers);
+                searchResult = esClient.search(query, searchType, index, type, scroll, headers, params);
             } catch (Exception e) {
                 throw DataXException.asDataXException(ESReaderErrorCode.ES_SEARCH_ERROR, e);
             }

--- a/elasticsearchreader/src/main/java/com/alibaba/datax/plugin/reader/elasticsearchreader/Key.java
+++ b/elasticsearchreader/src/main/java/com/alibaba/datax/plugin/reader/elasticsearchreader/Key.java
@@ -133,6 +133,10 @@ public final class Key {
         return conf.getMap("headers", new HashMap<>());
     }
 
+    public static Map<String, Object> getParams(Configuration conf) {
+        return conf.getMap("params", new HashMap<>());
+    }
+
     public static String getQuery(Configuration conf) {
         return conf.getConfiguration(Key.SEARCH_KEY).toString();
     }


### PR DESCRIPTION
工作中遇到es7.x返回的total的值是一个json字符串,但是在低版本中对应是一个简单的值.
对应的官方文档说明为: https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html
如果不进行修改,对应获取total的值的部分会报解析错误.
需要设置rest_total_hits_as_int=true 可以恢复低版本的返回格式. 故新增params配置,用来适配这种情况.
在parameter中配置 "params":{"rest_total_hits_as_int":true} 即可.